### PR TITLE
Do not re-validate output is utf8

### DIFF
--- a/datafusion/physical-plan/src/aggregates/group_values/group_column.rs
+++ b/datafusion/physical-plan/src/aggregates/group_values/group_column.rs
@@ -592,11 +592,17 @@ impl<B: ByteViewType> ByteViewGroupValueBuilder<B> {
 
         let views = ScalarBuffer::from(views);
 
-        Arc::new(GenericByteViewArray::<B>::new(
-            views,
-            completed,
-            null_buffer,
-        ))
+        // Safety:
+        // * all views were correctly made
+        // * (if utf8): Input was valid Utf8 so buffer contents are
+        // valid utf8 as well
+        unsafe {
+            Arc::new(GenericByteViewArray::<B>::new_unchecked(
+                views,
+                completed,
+                null_buffer,
+            ))
+        }
     }
 
     fn take_n_inner(&mut self, n: usize) -> ArrayRef {


### PR DESCRIPTION
Target https://github.com/apache/datafusion/pull/12809 from @Rachelint 

This avoids re-validating the output of byte view groups are valid UTF8 and results in a 10% performance improvement

See details and performace difference here:  https://github.com/apache/datafusion/pull/12809#discussion_r1798280082